### PR TITLE
Add external target example

### DIFF
--- a/examples/OktoResources/ResourceRelations/Connection/04.external-target-prometheus-insecure.yaml
+++ b/examples/OktoResources/ResourceRelations/Connection/04.external-target-prometheus-insecure.yaml
@@ -1,0 +1,20 @@
+apiVersion: blocks/v1beta1
+kind: Connection
+metadata:
+  name: connection-with-external-target
+  namespace: default
+  labels:
+    site.nbycomp.com/{{ .Values.placement.site.label }}: "true"
+    kind: K8sCluster
+spec:
+  externalTarget:
+    prometheus:
+      query: |-
+        (avg by (instance) 
+          (rate(node_cpu_seconds_total{job="node",mode="idle"}[1m])) * 100)
+        > 70
+      endpoint:
+        insecureValue: |
+          address: http://prometheus:9090
+  value: |
+    {{`{{ toYaml .Target }}`}}

--- a/examples/OktoResources/ResourceRelations/Connection/05.external-target-prometheus-connection.yaml
+++ b/examples/OktoResources/ResourceRelations/Connection/05.external-target-prometheus-connection.yaml
@@ -1,0 +1,21 @@
+apiVersion: blocks/v1beta1
+kind: Connection
+metadata:
+  name: connection-with-external-target
+  namespace: default
+  labels:
+    site.nbycomp.com/{{ .Values.placement.site.label }}: "true"
+    kind: K8sCluster
+spec:
+  externalTarget:
+    prometheus:
+      query: |-
+        (avg by (instance) 
+          (rate(node_cpu_seconds_total{job="node",mode="idle"}[1m])) * 100)
+        > 70
+      endpoint:
+        connectionRef:
+          name: prometheus-config
+          namespace: default
+  value: |
+    {{`{{ toYaml .Target }}`}}


### PR DESCRIPTION
This example add the external target for the Connection kind. This will save in the .Target connection's RenderedValues the result of the prometheus query in `{{ .Values.prometheus.query }}` querying the `{{ .Values.prometheus.address }}`, you can get it  by using the command `kubectl get nodes -o wide` for the cluster where prometheus is deployed and use the prometheus node port to reach the service.