### PR TITLE
Fix typo

### DIFF
--- a/examples/OktoResources/Deployments/Container/ChartDeployment/06.connection-list.yaml
+++ b/examples/OktoResources/Deployments/Container/ChartDeployment/06.connection-list.yaml
@@ -23,6 +23,6 @@ spec:
       version: 35.3.1
       values: |
         additionalPrometheusRules:
-          {{`{{- range .Connection.rules }}`}}
+          {{`{{- range .Connections.rules }}`}}
             - {{`{{ .rule }}`}}
           {{`{{- end }}`}}

--- a/examples/OktoResources/Deployments/Container/ChartDeployment/07.connection-list-fixed-length.yaml
+++ b/examples/OktoResources/Deployments/Container/ChartDeployment/07.connection-list-fixed-length.yaml
@@ -25,6 +25,6 @@ spec:
       version: 35.3.1
       values: |
         additionalPrometheusRules:
-          {{`{{- range .Connection.rules }}`}}
+          {{`{{- range .Connections.rules }}`}}
             - {{`{{ .rule }}`}}
           {{`{{- end }}`}}

--- a/examples/OktoResources/Deployments/Container/ChartDeployment/08.connection-list-interval-length.yaml
+++ b/examples/OktoResources/Deployments/Container/ChartDeployment/08.connection-list-interval-length.yaml
@@ -25,6 +25,6 @@ spec:
       version: 35.3.1
       values: |
         additionalPrometheusRules:
-          {{`{{- range .Connection.rules }}`}}
+          {{`{{- range .Connections.rules }}`}}
             - {{`{{ .rule }}`}}
           {{`{{- end }}`}}

--- a/examples/OktoResources/Deployments/Container/ChartDeployment/09.non-required-connection-list.yaml
+++ b/examples/OktoResources/Deployments/Container/ChartDeployment/09.non-required-connection-list.yaml
@@ -23,9 +23,9 @@ spec:
         url: https://charts.bitnami.com/bitnami
       version: 35.3.1
       values: |
-        {{`{{- if .Connection.rules }}`}}
+        {{`{{- if .Connections.rules }}`}}
         additionalPrometheusRules:
-          {{`{{- range .Connection.rules }}`}}
+          {{`{{- range .Connections.rules }}`}}
             - {{`{{ .rule }}`}}
           {{`{{- end }}`}}
         {{`{{- end }}`}}`


### PR DESCRIPTION
Fix typo in Connection examples
there's a few places where `.Connection.` should be `.Connections.`